### PR TITLE
Add workflow to convert and upload models to a cloud storage bucket

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@
 ^README\.Rmd$
 ^cran-comments\.md$
 ^\.github$
+^tools/convert-models\.py$
+^tools$

--- a/.github/workflows/models.yaml
+++ b/.github/workflows/models.yaml
@@ -1,0 +1,25 @@
+name: Convert and upload pre-trained models
+
+on:
+  workflow_dispatch:
+
+jobs:
+  upload:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - run: |
+          python -m pip install --upgrade pip
+          pip install torch google-cloud-storage requests
+      - run: |
+          python tools/convert-models.py
+

--- a/tools/convert-models.py
+++ b/tools/convert-models.py
@@ -1,4 +1,3 @@
-import torchvision
 import torch
 import requests
 from google.cloud import storage

--- a/tools/convert-models.py
+++ b/tools/convert-models.py
@@ -1,0 +1,55 @@
+import torchvision
+import torch
+import requests
+from google.cloud import storage
+import os
+
+version = "1"
+
+models = {
+  "bert-base-uncased": "https://huggingface.co/bert-base-uncased/resolve/main/pytorch_model.bin",
+  "bert-base-cased": "https://huggingface.co/bert-base-cased/resolve/main/pytorch_model.bin",
+  "bert-large-uncased": "https://huggingface.co/bert-large-uncased/resolve/main/pytorch_model.bin",
+  "bert-large-cased": "https://huggingface.co/bert-large-cased/resolve/main/pytorch_model.bin",
+  "bert-tiny": "https://huggingface.co/prajjwal1/bert-tiny/resolve/main/pytorch_model.bin",
+  "bert-mini": "https://huggingface.co/prajjwal1/bert-mini/resolve/main/pytorch_model.bin",
+  "bert-small": "https://huggingface.co/prajjwal1/bert-small/resolve/main/pytorch_model.bin",
+  "bert-medium": "https://huggingface.co/prajjwal1/bert-medium/resolve/main/pytorch_model.bin"
+}
+
+def upload_blob(bucket_name, source_file_name, destination_blob_name):
+    """Uploads a file to the bucket."""
+    # bucket_name = "your-bucket-name"
+    # source_file_name = "local/path/to/file"
+    # destination_blob_name = "storage-object-name"
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(destination_blob_name)
+
+    blob.upload_from_filename(source_file_name)
+
+    print(
+        "File {} uploaded to {}.".format(
+            source_file_name, destination_blob_name
+        )
+    )
+
+def download_file (url, filename):
+  r = requests.get(url, allow_redirects=True, stream=True)
+  with open(filename, 'wb') as f:
+    for chunk in r.iter_content(chunk_size=1024): 
+        if chunk: f.write(chunk)
+
+
+for name, url in models.items():
+  fpath = "weights.pt"
+  download_file(url, fpath)
+  d = dict(torch.load(fpath))
+  
+  torch.save(d, fpath, _use_new_zipfile_serialization=True)
+  upload_blob(
+    "torchtransformers-models",
+    fpath,
+    "name/v" + version + "/" + fpath 
+  )

--- a/tools/convert-models.py
+++ b/tools/convert-models.py
@@ -50,5 +50,5 @@ for name, url in models.items():
   upload_blob(
     "torchtransformers-models",
     fpath,
-    "name/v" + version + "/" + fpath 
+    name + "/v" + version + "/" + fpath 
   )


### PR DESCRIPTION
This allows uploading the models listed in `tools/convert-models.py` to the format that we can use in torch.
You can manually click 'Run Workflow' to make the uploads:

![image](https://user-images.githubusercontent.com/4706822/126380242-29135412-1884-447d-99ae-4ff0e0f4a75a.png)

I'll send you the auth details in private 
